### PR TITLE
Warn about existing commands

### DIFF
--- a/autoload/makery.vim
+++ b/autoload/makery.vim
@@ -32,6 +32,10 @@ endfunction
 
 function! s:CreateCommand(command, options) abort
   let l:command_name = 'M' . a:command
+  
+  if (exists(":" . l:command_name))
+      echom "The command :" . l:command_name . " is already defined elsewhere."
+  endif
 
   execute 'command! -bang -nargs=* -complete=file' l:command_name
     \ 'call makery#Make(' . string(a:options) . ', <q-bang>, <q-args>)'


### PR DESCRIPTION
This will make the user aware of any potential overwrites that they create.
For instance, the following `.makery.json` file will only register 1 command.
```
{
    "test": {"makeprg": "phpunit"},
    "aps": {"makeprg": "phpunit"}
}
```
Becase "aps" would be created as "Maps".