### PR TITLE
Add initial Projectionist support

### DIFF
--- a/plugin/makery.vim
+++ b/plugin/makery.vim
@@ -78,6 +78,13 @@ function! s:DetectJSON() abort
   endtry
 endfunction
 
+function! s:DetectProjectionist() abort
+  for [l:root, l:value] in projectionist#query('makery')
+    call makery#Setup(l:value)
+    break
+  endfor
+endfunction
+
 function! s:Detect() abort
   if v:version >= 800 || exists('*json_decode')
     call s:DetectJSON()
@@ -91,6 +98,7 @@ augroup Makery
   autocmd BufRead,BufNewFile * if &buftype !~# 'nofile\|quickfix' |
     \ call s:Detect() |
     \ endif
+  autocmd User ProjectionistActivate call s:DetectProjectionist()
 augroup END
 
 " vim:fdm=marker


### PR DESCRIPTION
Discussion in #5.

As of now, a simple projectionist#query() is done for a "makery" key.
This is expected to contain an object of the same shape as described in
:help makery-path-config.

This is especially convenient because it only entails calling
makery#Setup directly. However, later additions might want to take
advantage of smarter queries, e.g. use "make" and "dispatch" to some
extent?